### PR TITLE
Add support for A10 API v3 via warthog.core3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -39,8 +39,7 @@ load-plugins=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 
-# Disable "too few public methods"
-disable=R0903
+disable=duplicate-code,too-few-public-methods
 
 
 
@@ -76,9 +75,6 @@ msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input
@@ -209,10 +205,6 @@ ignore-imports=no
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -2,6 +2,14 @@ Changelog
 =========
 
 
+1.999.0 - ????-??-??
+--------------------
+* Add new :mod:`warthog.core3` module for support of A10 V3 APIs in parallel with the existing
+  core module as a transition to the new API.
+* Default to use of TLS version 1.2 when not otherwise specified.
+* **NOTE** This version is only meant to be used internally at SmarterTravel as a transition
+  step between two load balancers. As such, it is not available on PyPI.
+
 1.1.0 - 2016-01-21
 ------------------
 * Disable ``InsecurePlatformWarning`` from urllib3 by default for the CLI client since this makes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage==3.7.1
-Fabric==1.10.2
+Fabric==1.13.1
 mock==1.3.0
-pylint==1.4.4
+pylint==1.6.5
 pytest==2.7.3
 Sphinx==1.3.1
 sphinx-rtd-theme==0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.11.1
-click==6.6
+click==6.7

--- a/test/test_core3.py
+++ b/test/test_core3.py
@@ -1,0 +1,559 @@
+# -*- coding: utf-8 -*-
+
+import mock
+import pytest
+import requests
+
+import warthog.core3
+import warthog.exceptions
+
+SOME_CRAZY_ERROR = {
+    'response': {
+        'status': 'fail',
+        'err': {
+            'code': 10001,
+            'msg': 'You done did it now'
+        }
+    }
+}
+
+AUTH_SUCCESS = {
+    "authresponse": {
+        "signature": "ad44c3dfbac9440da876e7b3feaf1fc",
+        "description": "the signature should be set in Authorization header for following request."
+    }
+}
+
+BAD_PW = {
+    "authorizationschema": {
+        "code": 403,
+        "error": "Incorrect user name or password",
+        "auth_uri": "/axapi/v3/auth",
+        "logoff_uri": "/axapi/v3/logoff",
+        "username": "required",
+        "password": "required"
+    }
+}
+
+INVALID_SESSION = {
+    "authorizationschema": {
+        "code": 401,
+        "error": "Invalid admin session.",
+        "auth_uri": "/axapi/v3/auth",
+        "logoff_uri": "/axapi/v3/logoff",
+        "username": "required",
+        "password": "required"
+    }
+}
+
+NO_PERMISSIONS = {
+    "response": {
+        "status": "fail",
+        "err": {
+            "code": 419545856,
+            "from": "BACKEND",
+            "msg": "No write privilege of this admin session."
+        }
+    }
+}
+
+NO_SUCH_SERVER = {
+    "response": {
+        "status": "fail",
+        "err": {
+            "code": 1023460352,
+            "from": "CM",
+            "msg": "Object specified does not exist (object: server)"
+        }
+    }
+}
+
+OK_RESPONSE = {
+    'response': {
+        'status': 'OK'
+    }
+}
+
+NODE_OPER = {
+    "server": {
+        "oper": {
+            "state": "Up"
+        },
+        "port-list": [
+            {
+                "oper": {
+                    "state": "Up"
+                },
+                "a10-url": "/axapi/v3/slb/server/app1.example.com/port/80+tcp/oper",
+                "port-number": 80,
+                "protocol": "tcp"
+            }
+        ],
+        "a10-url": "/axapi/v3/slb/server/app1.example.com/oper",
+        "name": "app1.example.com"
+    }
+}
+
+NODE_STATS = {
+    "server": {
+        "stats": {
+            "curr-conn": 0,
+            "total-conn": 0,
+            "fwd-pkt": 0,
+            "rev-pkt": 0,
+            "peak-conn": 0,
+            "total_req": 0,
+            "total_req_succ": 0,
+            "curr_ssl_conn": 0,
+            "total_ssl_conn": 0,
+            "total_fwd_bytes": 0,
+            "total_rev_bytes": 0
+        },
+        "port-list": [
+            {
+                "stats": {
+                    "curr_conn": 0,
+                    "curr_req": 0,
+                    "total_req": 0,
+                    "total_req_succ": 0,
+                    "total_fwd_bytes": 0,
+                    "total_fwd_pkts": 0,
+                    "total_rev_bytes": 0,
+                    "total_rev_pkts": 0,
+                    "total_conn": 0,
+                    "last_total_conn": 0,
+                    "peak_conn": 0,
+                    "es_resp_200": 0,
+                    "es_resp_300": 0,
+                    "es_resp_400": 0,
+                    "es_resp_500": 0,
+                    "es_resp_other": 0,
+                    "es_req_count": 0,
+                    "es_resp_count": 0,
+                    "es_resp_invalid_http": 0,
+                    "total_rev_pkts_inspected": 0,
+                    "total_rev_pkts_inspected_good_status_code": 0,
+                    "response_time": 0,
+                    "fastest_rsp_time": 0,
+                    "slowest_rsp_time": 0,
+                    "curr_ssl_conn": 0,
+                    "total_ssl_conn": 0
+                },
+                "a10-url": "/axapi/v3/slb/server/app1.example.com/port/80+tcp/stats",
+                "port-number": 80,
+                "protocol": "tcp"
+            }
+        ],
+        "a10-url": "/axapi/v3/slb/server/app1.example.com/stats",
+        "name": "app1.example.com"
+    }
+}
+
+NODE_ALTER = {
+    "server": {
+        "name": "app1.example.com",
+        "host": "10.0.0.1",
+        "action": "enable",
+        "template-server": "default",
+        "health-check-disable": 0,
+        "conn-limit": 8000000,
+        "no-logging": 0,
+        "weight": 1,
+        "slow-start": 0,
+        "spoofing-cache": 0,
+        "stats-data-action": "stats-data-enable",
+        "extended-stats": 0,
+        "uuid": "7bdeee5c-56f0-44b5-a040-243a389f6fd1",
+        "port-list": [
+            {
+                "port-number": 80,
+                "protocol": "tcp",
+                "range": 0,
+                "template-port": "default",
+                "action": "enable",
+                "no-ssl": 0,
+                "health-check-disable": 0,
+                "weight": 1,
+                "conn-limit": 8000000,
+                "no-logging": 0,
+                "stats-data-action": "stats-data-enable",
+                "extended-stats": 0,
+                "uuid": "7bdeee5c-56f0-44b5-a040-243a389f6fd1",
+                "a10-url": "/axapi/v3/slb/server/app1.example.com/port/80+tcp"
+            }
+        ]
+    }
+}
+
+SCHEME_HOST = 'https://lb.example.com'
+
+
+@pytest.fixture
+def response():
+    return mock.Mock(spec=requests.Response)
+
+
+@pytest.fixture
+def transport(response):
+    mock_transport = mock.Mock(spec=requests.Session)
+    mock_transport.get.return_value = response
+    mock_transport.post.return_value = response
+    return mock_transport
+
+
+class TestSessionStartCommand(object):
+    def test_send_bad_password(self, transport, response):
+        response.text = ''
+        response.status_code = 403
+        response.ok = False
+        response.json.return_value = dict(BAD_PW)
+
+        with pytest.raises(warthog.exceptions.WarthogAuthFailureError):
+            cmd = warthog.core3.SessionStartCommand(transport, SCHEME_HOST, 'user', 'bad password')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post()" to be called'
+
+    def test_send_success(self, transport, response):
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = dict(AUTH_SUCCESS)
+
+        cmd = warthog.core3.SessionStartCommand(transport, SCHEME_HOST, 'user', 'password')
+        session = cmd.send()
+
+        assert 'ad44c3dfbac9440da876e7b3feaf1fc' == session, 'Did not get expected session ID'
+
+
+class TestSessionEndCommand(object):
+    def test_send_invalid_session(self, transport, response):
+        response.text = ''
+        response.status_code = 401
+        response.ok = False
+        response.json.return_value = dict(INVALID_SESSION)
+
+        with pytest.raises(warthog.exceptions.WarthogInvalidSessionError):
+            cmd = warthog.core3.SessionEndCommand(transport, SCHEME_HOST, 'bad session')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_unknown_error(self, transport, response):
+        response.text = ''
+        response.status_code = 503
+        response.ok = False
+        response.json.return_value = dict(SOME_CRAZY_ERROR)
+
+        with pytest.raises(warthog.exceptions.WarthogApiError):
+            cmd = warthog.core3.SessionEndCommand(transport, SCHEME_HOST, '1234')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_success(self, transport, response):
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = dict(OK_RESPONSE)
+
+        cmd = warthog.core3.SessionEndCommand(transport, SCHEME_HOST, '1234')
+        closed = cmd.send()
+        assert closed, 'Did not get expected True result from session close'
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+
+class TestNodeEnableCommand(object):
+    def test_send_invalid_session(self, transport, response):
+        response.text = ''
+        response.status_code = 401
+        response.ok = False
+        response.json.return_value = dict(INVALID_SESSION)
+
+        with pytest.raises(warthog.exceptions.WarthogInvalidSessionError):
+            cmd = warthog.core3.NodeEnableCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_no_such_server(self, transport, response):
+        response.text = ''
+        response.status_code = 404
+        response.ok = False
+        response.json.return_value = dict(NO_SUCH_SERVER)
+
+        with pytest.raises(warthog.exceptions.WarthogNoSuchNodeError):
+            cmd = warthog.core3.NodeEnableCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_no_permissions(self, transport, response):
+        response.text = ''
+        response.status_code = 400
+        response.ok = False
+        response.json.return_value = dict(NO_PERMISSIONS)
+
+        with pytest.raises(warthog.exceptions.WarthogPermissionError):
+            cmd = warthog.core3.NodeDisableCommand(
+                transport, SCHEME_HOST, '1234', 'app1.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_unknown_error(self, transport, response):
+        response.text = ''
+        response.status_code = 503
+        response.ok = False
+        response.json.return_value = dict(SOME_CRAZY_ERROR)
+
+        with pytest.raises(warthog.exceptions.WarthogApiError):
+            cmd = warthog.core3.NodeEnableCommand(
+                transport, SCHEME_HOST, '1234', 'good.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_success(self, transport, response):
+        result = dict(NODE_ALTER)
+        result['server']['action'] = 'enable'
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        cmd = warthog.core3.NodeEnableCommand(
+            transport, SCHEME_HOST, '1234', 'good.example.com')
+        got_enabled = cmd.send()
+        assert got_enabled, 'Did not get get expected True result from node enable'
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+
+class TestNodeDisableCommand(object):
+    def test_send_invalid_session(self, transport, response):
+        response.text = ''
+        response.status_code = 401
+        response.ok = False
+        response.json.return_value = dict(INVALID_SESSION)
+
+        with pytest.raises(warthog.exceptions.WarthogInvalidSessionError):
+            cmd = warthog.core3.NodeDisableCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_no_such_server(self, transport, response):
+        response.text = ''
+        response.status_code = 404
+        response.ok = False
+        response.json.return_value = dict(NO_SUCH_SERVER)
+
+        with pytest.raises(warthog.exceptions.WarthogNoSuchNodeError):
+            cmd = warthog.core3.NodeDisableCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_no_permissions(self, transport, response):
+        response.text = ''
+        response.status_code = 400
+        response.ok = False
+        response.json.return_value = dict(NO_PERMISSIONS)
+
+        with pytest.raises(warthog.exceptions.WarthogPermissionError):
+            cmd = warthog.core3.NodeDisableCommand(
+                transport, SCHEME_HOST, '1234', 'app1.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_unknown_error(self, transport, response):
+        response.text = ''
+        response.status_code = 503
+        response.ok = False
+        response.json.return_value = dict(SOME_CRAZY_ERROR)
+
+        with pytest.raises(warthog.exceptions.WarthogApiError):
+            cmd = warthog.core3.NodeDisableCommand(
+                transport, SCHEME_HOST, '1234', 'good.example.com')
+            cmd.send()
+
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+    def test_send_success(self, transport, response):
+        result = dict(NODE_ALTER)
+        result['server']['action'] = 'disable'
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        cmd = warthog.core3.NodeDisableCommand(
+            transport, SCHEME_HOST, '1234', 'good.example.com')
+        got_disabled = cmd.send()
+        assert got_disabled, 'Did not get get expected True result from node disable'
+        assert transport.post.called, 'Expected transport ".post() to be called'
+
+
+class TestNodeStatusCommand(object):
+    def test_send_invalid_session(self, transport, response):
+        response.text = ''
+        response.status_code = 401
+        response.ok = False
+        response.json.return_value = dict(INVALID_SESSION)
+
+        with pytest.raises(warthog.exceptions.WarthogInvalidSessionError):
+            cmd = warthog.core3.NodeStatusCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_no_such_server(self, transport, response):
+        response.text = ''
+        response.status_code = 404
+        response.ok = False
+        response.json.return_value = dict(NO_SUCH_SERVER)
+
+        with pytest.raises(warthog.exceptions.WarthogNoSuchNodeError):
+            cmd = warthog.core3.NodeStatusCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_unknown_error(self, transport, response):
+        response.text = ''
+        response.status_code = 503
+        response.ok = False
+        response.json.return_value = dict(SOME_CRAZY_ERROR)
+
+        with pytest.raises(warthog.exceptions.WarthogApiError):
+            cmd = warthog.core3.NodeStatusCommand(
+                transport, SCHEME_HOST, '1234', 'good.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_server_enabled(self, transport, response):
+        result = dict(NODE_OPER)
+        result['server']['oper']['state'] = 'Up'
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        cmd = warthog.core3.NodeStatusCommand(
+            transport, SCHEME_HOST, '1234', 'good.example.com')
+        status = cmd.send()
+        assert warthog.core3.STATUS_ENABLED == status, 'Did not get expected enabled status'
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_server_disabled(self, transport, response):
+        result = dict(NODE_OPER)
+        result['server']['oper']['state'] = 'Disabled'
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        cmd = warthog.core3.NodeStatusCommand(
+            transport, SCHEME_HOST, '1234', 'good.example.com')
+        status = cmd.send()
+        assert warthog.core3.STATUS_DISABLED == status, 'Did not get expected disabled status'
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_server_down(self, transport, response):
+        result = dict(NODE_OPER)
+        result['server']['oper']['state'] = 'Down'
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        cmd = warthog.core3.NodeStatusCommand(
+            transport, SCHEME_HOST, '1234', 'good.example.com')
+        status = cmd.send()
+        assert warthog.core3.STATUS_DOWN == status, 'Did not get expected down status'
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_server_no_known_status(self, transport, response):
+        result = dict(NODE_OPER)
+        result['server']['oper']['state'] = 'Shutdown'
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        with pytest.raises(warthog.exceptions.WarthogNodeStatusError):
+            cmd = warthog.core3.NodeStatusCommand(
+                transport, SCHEME_HOST, '1234', 'good.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+
+class TestNodeActiveConnectionsCommand(object):
+    def test_send_invalid_session(self, transport, response):
+        response.text = ''
+        response.status_code = 401
+        response.ok = False
+        response.json.return_value = dict(INVALID_SESSION)
+
+        with pytest.raises(warthog.exceptions.WarthogInvalidSessionError):
+            cmd = warthog.core3.NodeActiveConnectionsCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_no_such_server(self, transport, response):
+        response.text = ''
+        response.status_code = 404
+        response.ok = False
+        response.json.return_value = dict(NO_SUCH_SERVER)
+
+        with pytest.raises(warthog.exceptions.WarthogNoSuchNodeError):
+            cmd = warthog.core3.NodeActiveConnectionsCommand(
+                transport, SCHEME_HOST, '1234', 'bad.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_unknown_error(self, transport, response):
+        response.text = ''
+        response.status_code = 503
+        response.ok = False
+        response.json.return_value = dict(SOME_CRAZY_ERROR)
+
+        with pytest.raises(warthog.exceptions.WarthogApiError):
+            cmd = warthog.core3.NodeActiveConnectionsCommand(
+                transport, SCHEME_HOST, '1234', 'good.example.com')
+            cmd.send()
+
+        assert transport.get.called, 'Expected transport ".get() to be called'
+
+    def test_send_success(self, transport, response):
+        result = dict(NODE_STATS)
+        result['server']['stats']['curr-conn'] = 42
+
+        response.text = ''
+        response.status_code = 200
+        response.ok = True
+        response.json.return_value = result
+
+        cmd = warthog.core3.NodeActiveConnectionsCommand(
+            transport, SCHEME_HOST, '1234', 'good.example.com')
+        connections = cmd.send()
+        assert 42 == connections, 'Did not get expected active connections'
+        assert transport.get.called, 'Expected transport ".get() to be called'

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -30,3 +30,19 @@ def test_get_transport_factory_with_defaults():
 
     assert warthog.transport.DEFAULT_SSL_VERSION == adapter.ssl_version, 'Did not get default TLS version'
     assert warthog.transport.DEFAULT_CERT_VERIFY == session.verify, 'Did not get default verify setting'
+
+
+def test_default_tls_version_matches_ssl_module():
+    try:
+        import ssl
+        module_version = ssl.PROTOCOL_TLSv1_2
+    except AttributeError:
+        # Running an old version of Python that doesn't have the version
+        # constant. This is the reason we need to use our own and we can't
+        # verify that it's right here so just end.
+        return
+
+    # Make sure that our default version matches the actual constant in the
+    # ssl module. This is really just a sanity check to make sure this hack
+    # doesn't blow up in our face
+    assert module_version == warthog.transport.DEFAULT_SSL_VERSION

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py34
 
 [testenv]
 setenv = LANG=en_US.UTF-8

--- a/warthog/api.py
+++ b/warthog/api.py
@@ -42,6 +42,7 @@ from .exceptions import (
     WarthogNodeEnableError,
     WarthogNodeStatusError,
     WarthogNoSuchNodeError,
+    WarthogPermissionError,
     WarthogConfigError,
     WarthogMalformedConfigFileError,
     WarthogNoConfigFileError)
@@ -77,6 +78,7 @@ __all__ = [
     'WarthogNodeEnableError',
     'WarthogNodeStatusError',
     'WarthogNoSuchNodeError',
+    'WarthogPermissionError',
     'WarthogConfigError',
     'WarthogMalformedConfigFileError',
     'WarthogNoConfigFileError'

--- a/warthog/cli.py
+++ b/warthog/cli.py
@@ -16,11 +16,13 @@ CLI interface for interacting with a load balancer using the Warthog client.
 import functools
 import os
 import os.path
+
 import click
+import requests
+
 import warthog
 import warthog.api
 from .packages import six
-import requests
 
 
 def error_wrapper(func):

--- a/warthog/cli.py
+++ b/warthog/cli.py
@@ -124,6 +124,7 @@ def get_client(config):
         settings.scheme_host,
         settings.username,
         settings.password,
+        ssl_version=settings.ssl_version,
         verify=settings.verify))
 
 

--- a/warthog/core3.py
+++ b/warthog/core3.py
@@ -1,0 +1,514 @@
+# -*- coding: utf-8 -*-
+#
+# Warthog - Simple client for A10 load balancers
+#
+# Copyright 2014-2016 Smarter Travel
+#
+# Available under the MIT license. See LICENSE for details.
+#
+
+"""
+warthog.core3
+~~~~~~~~~~~~~
+
+Basic building blocks for authentication and interaction with a load balancer.
+"""
+
+import logging
+
+import requests
+
+import warthog.exceptions
+from .packages.six.moves import urllib
+
+STATUS_ENABLED = 'enabled'
+
+STATUS_DISABLED = 'disabled'
+
+STATUS_DOWN = 'down'
+
+ERROR_CODE_NO_SUCH_SERVER = 1023460352
+
+ERROR_CODE_BAD_PERMISSION = 419545856
+
+TRANSIENT_ERRORS = frozenset([])
+
+_PATH_AUTH = '/axapi/v3/auth'
+
+_PATH_LOGOFF = '/axapi/v3/logoff'
+
+_PATH_ENABLE = _PATH_DISABLE = '/axapi/v3/slb/server/{server}'
+
+_PATH_STATUS = '/axapi/v3/slb/server/{server}/oper'
+
+_PATH_CONNS = '/axapi/v3/slb/server/{server}/stats'
+
+
+def get_log():
+    """Get the :class:`logging.Logger` instance used by the Warthog library.
+
+    :return: Logger for the entire library
+    :rtype: logging.Logger
+    """
+    return logging.getLogger('warthog')
+
+
+def _extract_auth_error_from_payload(payload):
+    err = payload['authorizationschema']['error'].strip()
+    code = payload['authorizationschema']['code']
+    return err, code
+
+
+def _extract_other_error_from_payload(payload):
+    err = payload['response']['err']['msg'].strip()
+    code = payload['response']['err']['code']
+    return err, code
+
+
+class _AuthErrorHandler(object):
+    def __init__(self, host, user):
+        self._host = host
+        self._user = user
+
+    def can_handle(self, response):
+        return response.status_code == requests.codes.forbidden
+
+    def handle(self, response):
+        payload = response.json()
+        err, code = _extract_auth_error_from_payload(payload)
+
+        raise warthog.exceptions.WarthogAuthFailureError(
+            'Authentication failure using user "{0}" with {1}'.format(self._user, self._host),
+            api_msg=err, api_code=code
+        )
+
+
+class _SessionErrorHandler(object):
+    def __init__(self, token):
+        self._token = token
+
+    def can_handle(self, response):
+        return response.status_code == requests.codes.unauthorized
+
+    def handle(self, response):
+        payload = response.json()
+        err, code = _extract_auth_error_from_payload(payload)
+
+        raise warthog.exceptions.WarthogInvalidSessionError(
+            'Invalid session or token "{0}"'.format(self._token),
+            api_msg=err, api_code=code
+        )
+
+
+class _PermissionErrorHandler(object):
+    def __init__(self, server):
+        self._server = server
+
+    def can_handle(self, response):
+        if response.status_code != requests.codes.bad_request:
+            return False
+
+        payload = response.json()
+        _, code = _extract_other_error_from_payload(payload)
+        return code == ERROR_CODE_BAD_PERMISSION
+
+    def handle(self, response):
+        payload = response.json()
+        err, code = _extract_other_error_from_payload(payload)
+
+        raise warthog.exceptions.WarthogPermissionError(
+            'Insufficient permissions to complete operation on {0}'.format(self._server),
+            api_msg=err, api_code=code, server=self._server
+        )
+
+
+class _NoSuchServerErrorHandler(object):
+    def __init__(self, server):
+        self._server = server
+
+    def can_handle(self, response):
+        if response.status_code != requests.codes.not_found:
+            return False
+
+        payload = response.json()
+        _, code = _extract_other_error_from_payload(payload)
+        return code == ERROR_CODE_NO_SUCH_SERVER
+
+    def handle(self, response):
+        payload = response.json()
+        err, code = _extract_other_error_from_payload(payload)
+
+        raise warthog.exceptions.WarthogNoSuchNodeError(
+            'No such node {0}'.format(self._server),
+            api_msg=err, api_code=code, server=self._server
+        )
+
+
+class _OtherErrorHandler(object):
+    def can_handle(self, response):
+        return not response.ok
+
+    def handle(self, response):
+        payload = response.json()
+        err, code = _extract_other_error_from_payload(payload)
+
+        raise warthog.exceptions.WarthogApiError(
+            'Unexpected API error, HTTP code {0}'.format(response.status_code),
+            api_msg=err, api_code=code
+        )
+
+
+class _SuccessHandler(object):
+    def can_handle(self, _):
+        return True
+
+    def handle(self, response):
+        return response.json()
+
+
+class _ResponseHandlerMixin(object):
+    """Mixin class for translating error responses to WarthogApiError instances."""
+
+    def _extract_payload(self, response):
+        server = getattr(self, '_server', None)
+        host = getattr(self, '_scheme_host', None)
+        user = getattr(self, '_username', None)
+        auth = getattr(self, '_auth_token', None)
+
+        handlers = [
+            _AuthErrorHandler(host, user),
+            _SessionErrorHandler(auth),
+            _NoSuchServerErrorHandler(server),
+            _PermissionErrorHandler(server),
+            _OtherErrorHandler(),
+            _SuccessHandler()
+        ]
+
+        for handler in handlers:
+            if handler.can_handle(response):
+                return handler.handle(response)
+
+        raise RuntimeError(
+            "At least one configured handler should be able to handle the "
+            "response (code {code}) but none did. This most likely indicates "
+            "a bug in the Warthog library. Response {response}".format(
+                code=response.status_code, response=response.text
+            )
+        )
+
+
+def _get_endpoint_url(scheme_host, path):
+    return urllib.parse.urljoin(scheme_host, path)
+
+
+class SessionStartCommand(_ResponseHandlerMixin):
+    """Command to authenticate with the load balancer and start a new session
+    to be used by subsequent commands.
+
+    This class is thread safe.
+    """
+    _logger = get_log()
+
+    def __init__(self, transport, scheme_host, username, password):
+        """Set the transport layer and necessary credentials to authenticate with
+        the load balancer.
+
+        :param requests.Session transport: Configured requests session instance to
+            use for making HTTP or HTTPS requests to the load balancer API.
+        :param basestring scheme_host: Scheme and hostname of the load balancer to use for
+            making API requests. E.g. 'https://lb.example.com' or 'http://10.1.2.3'.
+        :param basestring username: Name of the user to authenticate with.
+        :param basestring password: Password for the user to authenticate with.
+        """
+        self._transport = transport
+        self._scheme_host = scheme_host
+        self._username = username
+        self._password = password
+
+    def send(self):
+        """Make an authentication request and return the session token that should
+        be included in all subsequent requests to the load balancer.
+
+        :return: The session token that should be used for all subsequent requests
+            made to the load balancer.
+        :rtype: unicode
+        :raises warthog.exceptions.WarthogAuthFailureError: If the authentication
+            failed for some reason. The exception will contain an error message and
+            error code that provides more detail about the failure. Common reasons
+            for this error include using invalid username or password.
+        """
+        url = _get_endpoint_url(self._scheme_host, _PATH_AUTH)
+        params = {
+            'credentials': {
+                'username': self._username,
+                'password': self._password
+            }
+        }
+
+        self._logger.debug('Making session start POST request to %s', url)
+        response = self._transport.post(url, json=params)
+        self._logger.debug(response.text)
+
+        payload = self._extract_payload(response)
+        return payload['authresponse']['signature']
+
+
+class _AuthenticatedCommand(object):
+    """Base class for making requests to the load balancer using an existing session
+    ID from a previous :class:`SessionStartCommand` request.
+
+    :ivar requests.Session _transport:
+    :ivar basestring _scheme_host:
+    :ivar basestring _session_id:
+    """
+    _logger = get_log()
+
+    def __init__(self, transport, scheme_host, auth_token):
+        """Set the requests transport layer, scheme and host of the load balancer,
+        and existing session ID to use for authentication.
+
+        :param requests.Session transport: Configured requests session instance to
+            use for making HTTP or HTTPS requests to the load balancer API.
+        :param basestring scheme_host: Scheme and hostname of the load balancer to use for
+            making API requests. E.g. 'https://lb.example.com' or 'http://10.1.2.3'.
+        :param basestring auth_token: Auth token from a previous authentication request
+            made to the load balancer.
+        """
+        self._transport = transport
+        self._scheme_host = scheme_host
+        self._auth_token = auth_token
+
+    def _auth_header(self):
+        return {'Authorization': 'A10 {auth}'.format(auth=self._auth_token)}
+
+    def send(self):
+        """Abstract method for making a request to the load balancer API and parsing
+        the result and returning any meaningful information (implementation specific).
+        """
+        raise NotImplementedError()
+
+
+class SessionEndCommand(_AuthenticatedCommand, _ResponseHandlerMixin):
+    """Command for ending a previously authenticated session with the load balancer.
+
+    This class is thread safe.
+    """
+
+    def send(self):
+        """Close an existing session and return ``True`` if closing it was successful.
+
+        :return: True if the current session could be closed
+        :rtype: bool
+        :raises warthog.exceptions.WarthogApiError: If the session could not be
+            closed. This is usually the result of the session ID being invalid or the
+            session already being closed before this command is run.
+        """
+        url = _get_endpoint_url(self._scheme_host, _PATH_LOGOFF)
+
+        self._logger.debug('Making session close POST request to %s', url)
+        response = self._transport.post(url, headers=self._auth_header())
+        self._logger.debug(response.text)
+        payload = self._extract_payload(response)
+
+        return payload['response']['status'] == 'OK'
+
+
+class NodeEnableCommand(_AuthenticatedCommand, _ResponseHandlerMixin):
+    """Command to mark a particular server as enabled.
+
+    This class is thread safe.
+    """
+
+    def __init__(self, transport, scheme_host, auth_token, server):
+        """Set the requests transport layer, scheme and host of the load balancer,
+        existing session ID to use for authentication, and hostname of the server
+        to enable.
+
+        :param requests.Session transport: Configured requests session instance to
+            use for making HTTP or HTTPS requests to the load balancer API.
+        :param basestring scheme_host: Scheme and hostname of the load balancer to use for
+            making API requests. E.g. 'https://lb.example.com' or 'http://10.1.2.3'.
+        :param basestring auth_token: Session ID from a previous authentication request
+            made to the load balancer.
+        :param basestring server: Host name of the server to enable.
+        """
+        super(NodeEnableCommand, self).__init__(transport, scheme_host, auth_token)
+        self._server = server
+
+    def send(self):
+        """Mark a server as 'enabled' at the node level and return ``True`` if it was
+        successfully enabled.
+
+        :return: True if the server was marked as enabled
+        :rtype: bool
+        :raises warthog.exceptions.WarthogInvalidSessionError: If the load balancer
+            did not recognize the session this command is being run as part of.
+        :raises warthog.exceptions.WarthogNoSuchNodeError: If the server was not
+            recognized by the load balancer.
+        :raises warthog.exceptions.WarthogPermissionError: If the user doesn't
+            have the required permissions to enable the server.
+        :raises warthog.exceptions.WarthogApiError: If the server could not be
+            enabled for any other reason.
+        """
+        url = _get_endpoint_url(self._scheme_host, _PATH_ENABLE)
+        url = url.format(server=self._server)
+        params = {'server': {'action': 'enable'}}
+
+        self._logger.debug('Making node enable POST request for %s', self._server)
+        response = self._transport.post(url, headers=self._auth_header(), json=params)
+        self._logger.debug(response.text)
+        payload = self._extract_payload(response)
+
+        return payload['server']['action'] == 'enable'
+
+
+class NodeDisableCommand(_AuthenticatedCommand, _ResponseHandlerMixin):
+    """Command to mark a particular server as disabled.
+
+    This class is thread safe.
+    """
+
+    def __init__(self, transport, scheme_host, session_id, server):
+        """Set the requests transport layer, scheme and host of the load balancer,
+        existing session ID to use for authentication, and hostname of the server
+        to disable.
+
+        :param requests.Session transport: Configured requests session instance to
+            use for making HTTP or HTTPS requests to the load balancer API.
+        :param basestring scheme_host: Scheme and hostname of the load balancer to use for
+            making API requests. E.g. 'https://lb.example.com' or 'http://10.1.2.3'.
+        :param basestring session_id: Session ID from a previous authentication request
+            made to the load balancer.
+        :param basestring server: Host name of the server to disable.
+        """
+        super(NodeDisableCommand, self).__init__(transport, scheme_host, session_id)
+        self._server = server
+
+    def send(self):
+        """Mark a server as 'disabled' at the node level and return ``True`` if it
+        was successfully disabled.
+
+        :return: True if the server was marked as disabled
+        :rtype: bool
+        :raises warthog.exceptions.WarthogInvalidSessionError: If the load balancer
+            did not recognize the session this command is being run as part of.
+        :raises warthog.exceptions.WarthogNoSuchNodeError: If the server was not
+            recognized by the load balancer.
+        :raises warthog.exceptions.WarthogPermissionError: If the user doesn't
+            have the required permissions to disable the server.
+        :raises warthog.exceptions.WarthogApiError: If the server could not be
+            disabled for any other reason.
+        """
+        url = _get_endpoint_url(self._scheme_host, _PATH_DISABLE)
+        url = url.format(server=self._server)
+        params = {'server': {'action': 'disable'}}
+
+        self._logger.debug('Making node disable POST request for %s', self._server)
+        response = self._transport.post(url, headers=self._auth_header(), json=params)
+        self._logger.debug(response.text)
+        payload = self._extract_payload(response)
+
+        return payload['server']['action'] == 'disable'
+
+
+class NodeStatusCommand(_AuthenticatedCommand, _ResponseHandlerMixin):
+    """Command to get the current status ('enabled', 'disabled', 'down') of a particular
+    server.
+
+    This class is thread safe.
+    """
+
+    def __init__(self, transport, scheme_host, session_id, server):
+        """Set the requests transport layer, scheme and host of the load balancer,
+        existing session ID to use for authentication, and hostname of the server
+        to get the status of.
+
+        :param requests.Session transport: Configured requests session instance to
+            use for making HTTP or HTTPS requests to the load balancer API.
+        :param basestring scheme_host: Scheme and hostname of the load balancer to use for
+            making API requests. E.g. 'https://lb.example.com' or 'http://10.1.2.3'.
+        :param basestring session_id: Session ID from a previous authentication request
+            made to the load balancer.
+        :param basestring server: Host name of the server to get the status of.
+        """
+        super(NodeStatusCommand, self).__init__(transport, scheme_host, session_id)
+        self._server = server
+
+    def send(self):
+        """Get the current status of a server at the node level and return one of the
+        ``STATUS_ENABLED``, ``STATUS_DISABLED``, ``STATUS_DOWN`` constants.
+
+        :return: The status of the server as a constant string
+        :rtype: basestring
+        :raises warthog.exceptions.WarthogInvalidSessionError: If the load balancer
+            did not recognize the session this command is being run as part of.
+        :raises warthog.exceptions.WarthogNoSuchNodeError: If the server was not
+            recognized by the load balancer.
+        :raises warthog.exceptions.WarthogNodeStatusError: If the status of the server
+            was not a recognized status.
+        :raises warthog.exceptions.WarthogApiError: If there are any other problems
+            getting the status of the server.
+        """
+        url = _get_endpoint_url(self._scheme_host, _PATH_STATUS)
+        url = url.format(server=self._server)
+
+        self._logger.debug('Making node status GET request for %s', self._server)
+        response = self._transport.get(url, headers=self._auth_header())
+        self._logger.debug(response.text)
+        payload = self._extract_payload(response)
+
+        status = payload['server']['oper']['state']
+        if status == 'Disabled':
+            return STATUS_DISABLED
+        if status == 'Up':
+            return STATUS_ENABLED
+        if status == 'Down':
+            return STATUS_DOWN
+
+        raise warthog.exceptions.WarthogNodeStatusError(
+            'Unknown status of {0}: status={1}'.format(self._server, status))
+
+
+class NodeActiveConnectionsCommand(_AuthenticatedCommand, _ResponseHandlerMixin):
+    """Command to get the number of active connections to a particular server.
+
+    This class is thread safe.
+    """
+
+    def __init__(self, transport, scheme_host, session_id, server):
+        """Set the requests transport layer, scheme and host of the load balancer,
+        existing session ID to use for authentication, and hostname of the server
+        to get active connections for.
+
+        :param requests.Session transport: Configured requests session instance to
+            use for making HTTP or HTTPS requests to the load balancer API.
+        :param basestring scheme_host: Scheme and hostname of the load balancer to use for
+            making API requests. E.g. 'https://lb.example.com' or 'http://10.1.2.3'.
+        :param basestring session_id: Session ID from a previous authentication request
+            made to the load balancer.
+        :param basestring server: Host name of the server to get active connections for.
+        """
+        super(NodeActiveConnectionsCommand, self).__init__(transport, scheme_host, session_id)
+        self._server = server
+
+    def send(self):
+        """Get the current number of active connections for a node as an int.
+
+        :return: The number of active connections for a node across all ports
+        :rtype: int
+        :raises warthog.exceptions.WarthogInvalidSessionError: If the load balancer
+            did not recognize the session this command is being run as part of.
+        :raises warthog.exceptions.WarthogNoSuchNodeError: If the server was not
+            recognized by the load balancer.
+        :raises warthog.exceptions.WarthogApiError: If the number of active
+            connections to the server could not be determined for any other reason.
+        """
+        url = _get_endpoint_url(self._scheme_host, _PATH_CONNS)
+        url = url.format(server=self._server)
+
+        self._logger.debug('Making active connection count GET request for %s', self._server)
+        response = self._transport.get(url, headers=self._auth_header())
+        self._logger.debug(response.text)
+        payload = self._extract_payload(response)
+
+        return payload['server']['stats']['curr-conn']

--- a/warthog/core3.py
+++ b/warthog/core3.py
@@ -19,6 +19,7 @@ import logging
 import requests
 
 import warthog.exceptions
+# pylint: disable=import-error,no-name-in-module
 from .packages.six.moves import urllib
 
 STATUS_ENABLED = 'enabled'
@@ -53,12 +54,14 @@ def get_log():
     return logging.getLogger('warthog')
 
 
+# pylint: disable=invalid-name,missing-docstring
 def _extract_auth_error_from_payload(payload):
     err = payload['authorizationschema']['error'].strip()
     code = payload['authorizationschema']['code']
     return err, code
 
 
+# pylint: disable=invalid-name,missing-docstring
 def _extract_other_error_from_payload(payload):
     err = payload['response']['err']['msg'].strip()
     code = payload['response']['err']['code']
@@ -70,7 +73,9 @@ class _AuthErrorHandler(object):
         self._host = host
         self._user = user
 
+    # pylint: disable=no-self-use
     def can_handle(self, response):
+        # pylint: disable=no-member
         return response.status_code == requests.codes.forbidden
 
     def handle(self, response):
@@ -87,7 +92,9 @@ class _SessionErrorHandler(object):
     def __init__(self, token):
         self._token = token
 
+    # pylint: disable=no-self-use
     def can_handle(self, response):
+        # pylint: disable=no-member
         return response.status_code == requests.codes.unauthorized
 
     def handle(self, response):
@@ -104,7 +111,9 @@ class _PermissionErrorHandler(object):
     def __init__(self, server):
         self._server = server
 
+    # pylint: disable=no-self-use
     def can_handle(self, response):
+        # pylint: disable=no-member
         if response.status_code != requests.codes.bad_request:
             return False
 
@@ -126,7 +135,9 @@ class _NoSuchServerErrorHandler(object):
     def __init__(self, server):
         self._server = server
 
+    # pylint: disable=no-self-use
     def can_handle(self, response):
+        # pylint: disable=no-member
         if response.status_code != requests.codes.not_found:
             return False
 
@@ -145,9 +156,11 @@ class _NoSuchServerErrorHandler(object):
 
 
 class _OtherErrorHandler(object):
+    # pylint: disable=no-self-use
     def can_handle(self, response):
         return not response.ok
 
+    # pylint: disable=no-self-use
     def handle(self, response):
         payload = response.json()
         err, code = _extract_other_error_from_payload(payload)
@@ -159,9 +172,11 @@ class _OtherErrorHandler(object):
 
 
 class _SuccessHandler(object):
+    # pylint: disable=no-self-use
     def can_handle(self, _):
         return True
 
+    # pylint: disable=no-self-use
     def handle(self, response):
         return response.json()
 

--- a/warthog/exceptions.py
+++ b/warthog/exceptions.py
@@ -84,11 +84,15 @@ class WarthogAuthFailureError(WarthogApiError):
 
 
 class WarthogInvalidSessionError(WarthogApiError):
-    """The session ID used while performing some action is unrecognized."""
+    """The session ID or auth token used while performing some action is unrecognized."""
 
 
 class WarthogAuthCloseError(WarthogApiError):
-    """There was some error while trying to end a session."""
+    """There was some error while trying to end a session.
+
+    .. deprecated:: 1.999.0
+        Cases that previously raised this exception will now raise :class:`WarthogApiError`
+    """
 
 
 class WarthogNodeError(WarthogApiError):
@@ -103,13 +107,30 @@ class WarthogNoSuchNodeError(WarthogNodeError):
     """The host being operated on is unrecognized."""
 
 
+class WarthogPermissionError(WarthogNodeError):
+    """The credentials lack required permissions to perform an operation.
+
+    .. versionadded:: 1.999.0
+    """
+
+
 class WarthogNodeStatusError(WarthogNodeError):
     """There was some error while getting the status of a node."""
 
 
 class WarthogNodeEnableError(WarthogNodeError):
-    """There was some error while trying to enable a node."""
+    """There was some error while trying to enable a node.
+
+    .. deprecated:: 1.999.0
+        Cases that previously raised this exception will now raise :class:`WarthogApiError`
+        or :class:`WarthogPermissionError`
+    """
 
 
 class WarthogNodeDisableError(WarthogNodeError):
-    """There was some error while trying to disable a node."""
+    """There was some error while trying to disable a node.
+
+    .. deprecated:: 1.999.0
+        Cases that previously raised this exception will now raise :class:`WarthogApiError`
+        or :class:`WarthogPermissionError`
+    """

--- a/warthog/transport.py
+++ b/warthog/transport.py
@@ -14,24 +14,27 @@ warthog.transport
 Methods to configure how to interact with the load balancer API over HTTP or HTTPS.
 """
 
-import ssl
-
-import warnings
 import requests
+import warnings
 from requests.adapters import (
     HTTPAdapter,
     DEFAULT_POOLBLOCK,
     DEFAULT_POOLSIZE,
     DEFAULT_RETRIES)
-from requests.packages.urllib3.poolmanager import PoolManager
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from requests.packages.urllib3.poolmanager import PoolManager
 
+# HACK: We need to default to TLSv1.2 to work with the new load balancer
+# but Python 2.6 and Python 3.3 don't have the TLSv1.2 constant. BUT, TLS
+# version 1.2 will work with the version of requests we use on Python 2.6
+# so we hack in the constant here for the sake of a default.
+_PROTOCOL_TLSv1_2 = 5
 
 # Default to using the SSL/TLS version that the A10 requires instead of
 # the default that the requests/urllib3 library picks. Or, maybe the A10
 # just doesn't allow the client to negotiate. Either way, we use TLSv1.2.
 # pylint: disable=no-member
-DEFAULT_SSL_VERSION = ssl.PROTOCOL_TLSv1_2
+DEFAULT_SSL_VERSION = _PROTOCOL_TLSv1_2
 
 # Default to verifying SSL/TLS certs because "safe by default" is a good idea.
 DEFAULT_CERT_VERIFY = True

--- a/warthog/transport.py
+++ b/warthog/transport.py
@@ -29,9 +29,9 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 # Default to using the SSL/TLS version that the A10 requires instead of
 # the default that the requests/urllib3 library picks. Or, maybe the A10
-# just doesn't allow the client to negotiate. Either way, we use TLSv1.
+# just doesn't allow the client to negotiate. Either way, we use TLSv1.2.
 # pylint: disable=no-member
-DEFAULT_SSL_VERSION = ssl.PROTOCOL_TLSv1
+DEFAULT_SSL_VERSION = ssl.PROTOCOL_TLSv1_2
 
 # Default to verifying SSL/TLS certs because "safe by default" is a good idea.
 DEFAULT_CERT_VERIFY = True

--- a/warthog/transport.py
+++ b/warthog/transport.py
@@ -14,8 +14,10 @@ warthog.transport
 Methods to configure how to interact with the load balancer API over HTTP or HTTPS.
 """
 
-import requests
 import warnings
+
+import requests
+
 from requests.adapters import (
     HTTPAdapter,
     DEFAULT_POOLBLOCK,
@@ -28,12 +30,12 @@ from requests.packages.urllib3.poolmanager import PoolManager
 # but Python 2.6 and Python 3.3 don't have the TLSv1.2 constant. BUT, TLS
 # version 1.2 will work with the version of requests we use on Python 2.6
 # so we hack in the constant here for the sake of a default.
+# pylint: disable=invalid-name
 _PROTOCOL_TLSv1_2 = 5
 
 # Default to using the SSL/TLS version that the A10 requires instead of
 # the default that the requests/urllib3 library picks. Or, maybe the A10
 # just doesn't allow the client to negotiate. Either way, we use TLSv1.2.
-# pylint: disable=no-member
 DEFAULT_SSL_VERSION = _PROTOCOL_TLSv1_2
 
 # Default to verifying SSL/TLS certs because "safe by default" is a good idea.


### PR DESCRIPTION
Add support for v3 of the A10 API via the `warthog.core3` module. This module is a copy of `warthog.core` modified to work with the v3 API.

Notable changes (besides different URLs and expected response format):
* Better error handling
* Deprecation of some exception types
* Addition of some new exceptions
* Default to TLS version 1.2 (if not otherwise specified)
